### PR TITLE
Fix: ImposterPrinter should also print allowCORS property

### DIFF
--- a/src/models/imposterPrinter.js
+++ b/src/models/imposterPrinter.js
@@ -30,6 +30,9 @@ function create (header, server, loadRequests) {
         if (header.endOfRequestResolver) {
             result.endOfRequestResolver = header.endOfRequestResolver;
         }
+        if (header.allowCORS) {
+            result.allowCORS = header.allowCORS;
+        }
 
         return result;
     }

--- a/test/models/imposterTest.js
+++ b/test/models/imposterTest.js
@@ -147,11 +147,12 @@ describe('imposter', function () {
             server.port = 3535;
             metadata.key = 'value';
 
-            const imposter = await Imposter.create(Protocol, { protocol: 'test' }, logger, {}, allow),
+            const imposter = await Imposter.create(Protocol, { protocol: 'test', allowCORS: true }, logger, {}, allow),
                 json = await imposter.toJSON({ replayable: true });
 
             assert.deepEqual(json, {
                 protocol: 'test',
+                allowCORS: true,
                 port: 3535,
                 recordRequests: false,
                 stubs: [],


### PR DESCRIPTION
Fixes https://github.com/bbyars/mountebank/issues/760 