### PR TITLE
Make mountebank-formatters dependency optional

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "2.9.2",
       "license": "MIT",
       "dependencies": {
-        "@mbtest/mountebank-formatters": "0.0.2",
         "@xmldom/xmldom": "0.8.10",
         "cors": "2.8.5",
         "csv-parse": "5.5.3",
@@ -52,6 +51,9 @@
       },
       "engines": {
         "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@mbtest/mountebank-formatters": "0.0.2"
       }
     },
     "mbTest": {
@@ -1246,6 +1248,7 @@
       "resolved": "https://registry.npmjs.org/@mbtest/mountebank-formatters/-/mountebank-formatters-0.0.2.tgz",
       "integrity": "sha512-wN5yd3WBtmyrZIapIwYH4rAxQVYF8Qoro7UU4SeCbA8M/TtTBMfVQg+2cZkat79IeJujrjS4NOAZLya9rEf/mw==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "ejs": "2.7.4",
         "fs-extra": "9.0.1"
@@ -1260,6 +1263,7 @@
       "integrity": "sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1269,6 +1273,7 @@
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
       "integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "at-least-node": "^1.0.0",
         "graceful-fs": "^4.2.0",
@@ -1284,6 +1289,7 @@
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
       "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -2188,6 +2194,7 @@
       "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
       "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
       "license": "ISC",
+      "optional": true,
       "engines": {
         "node": ">= 4.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "https-proxy-agent": "7.0.2",
     "jsonpath-plus": "10.3.0",
     "mailparser": "3.6.7",
-    "@mbtest/mountebank-formatters": "0.0.2",
     "nodemailer": "6.9.9",
     "prom-client": "15.1.0",
     "proper-lockfile": "4.1.2",
@@ -90,6 +89,9 @@
     "nc": "^1.0.3",
     "nyc": "^17.1.0",
     "snyk": "1.1297.3"
+  },
+  "optionalDependencies": {
+    "@mbtest/mountebank-formatters": "0.0.2"
   },
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
The mountebank CLI allows users to specify a custom formatter in place of the default `@mbtest/mountebank-formatters` module. This was done in part to [isolate that module's dependency on EJS](https://github.com/mountebank-testing/mountebank/commit/4aa45beb71d251d0a7de40cb8f1561166fecb61a).

Since the `@mbtest/mountebank-formatters` module might not be necessary at runtime (if the user supplies a custom formatter), it would be nice to make it an optional dependency. This enables users to install mountebank without the default formatter via `npm install --omit=optional mountebank`.

I'd personally like this change because it enables installing mountebank without installing EJS 2.7.4, which has been flagged for security vulnerabilities.

Thank you 🙂 