### PR TITLE
Temporarily disable coverage report upload due to third-party service errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,10 +60,10 @@ jobs:
             npm run test:cover
       - qlty/coverage_publish: # Upload coverage report to qlty.sh
           files: coverage/lcov.info
-      - run:
-          name: Upload coverage report to coveralls
-          command: |
-            cat ./coverage/lcov.info | node_modules/coveralls/bin/coveralls.js
+      # - run:
+      #     name: Upload coverage report to coveralls
+      #     command: |
+      #       cat ./coverage/lcov.info | node_modules/coveralls/bin/coveralls.js
 #      - run:
 #          name: Run sonar report
 #          command: |


### PR DESCRIPTION
The build is failing due to a 504 when uploading the coverage report. It seems like there was an outage similar to that a couple days ago: https://status.coveralls.io/

They claim it's resolved, but it may be happening still (or again). I'm going to temporarily disable this job so that I can get a clean pipeline for release.

@jarl-dk for visibility