### PR TITLE
Add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+    cooldown:
+      default-days: 7
+      semver-major-days: 7
+      semver-minor-days: 7
+      semver-patch-days: 7
+    groups:
+      npm-minor-patch-updates:
+        applies-to: "version-updates"
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,15 +4,21 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-      day: "wednesday"
+      day: "monday"
     cooldown:
       default-days: 7
       semver-major-days: 7
       semver-minor-days: 7
       semver-patch-days: 7
     groups:
-      npm-minor-patch-updates:
+      npm-minor-patch-version-updates:
         applies-to: "version-updates"
         update-types:
           - "minor"
           - "patch"
+      npm-minor-patch-security-updates:
+        applies-to: "security-updates"
+        update-types:
+          - "minor"
+          - "patch"
+

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,9 @@
 version: 2
 updates:
   - package-ecosystem: "npm"
-    directory: "/"
+    directories:
+      - "/"
+      - "/mbTest"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -21,4 +23,3 @@ updates:
         update-types:
           - "minor"
           - "patch"
-


### PR DESCRIPTION
## Summary

As a user of Mountebank I often see it flagged with CVEs due to its dependencies. I noticed there are a lot of open Dependabot PRs sitting and waiting to be merged. Several of them are aimed to fix those CVEs. This PR configures it to ease the management of dependency updates by grouping multiple updates into a single PR (for minor and patch updates). It also avoid pulling fresh unvetted packages through cooldown.

## Changes

- Adds Dependabot config.