### PR TITLE
Harden npm installs from supply chain attacks

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,8 @@
 save-exact=true
+# Ensures that npm doesn't pull fresh unvetted packages.
+min-release-age=7
+# Ensures that npm doesn't run scripts during install, through which
+# 99% of supply chain attacks are executed.
+ignore-scripts=true
+# Ensures that npm doesn't allow git dependencies that can bypass above settings.
+allow-git=none


### PR DESCRIPTION
## Summary

Nowadays supply chain attacks are more prevalent than ever and it would be a shame to be attacked via Mountebank, hence why it makes sense to implement several of best practices from https://github.com/lirantal/npm-security-best-practices.

## Changes

- Sets minimum age of packages that can be installed to 7 days.
- Disables any installation scripts.
- Disallows git based dependencies.